### PR TITLE
Fixing cache issue

### DIFF
--- a/src/Cache/DrupalCache.php
+++ b/src/Cache/DrupalCache.php
@@ -25,7 +25,11 @@ class DrupalCache extends CacheProvider
      */
     protected function doFetch($id)
     {
-        return $this->cache->get($id);
+        if ($cache = $this->cache->get($id)) {
+          return $cache->data;
+        }
+
+        return false;
     }
 
     /**

--- a/tests/src/Unit/Cache/DrupalCacheTest.php
+++ b/tests/src/Unit/Cache/DrupalCacheTest.php
@@ -6,15 +6,17 @@ use Drupal\controller_annotations\Cache\DrupalCache;
 use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Tests\UnitTestCase;
 use Mockery as m;
+use StdClass;
 
 class DrupalCacheTest extends UnitTestCase
 {
     public function testDoFetch()
     {
         $drupalCache = $this->getDrupalCacheMock();
-        $drupalCache->shouldReceive('get')->once()->withArgs(['[foo][1]'])->andReturn('bar');
+        $drupalCache->shouldReceive('get')->once()->withArgs(['[foo][1]'])->andReturn($this->getCacheData('bar'));
 
         $cache = new DrupalCache($drupalCache);
+
         $this->assertEquals('bar', $cache->fetch('foo'));
 
         m::close();
@@ -23,7 +25,7 @@ class DrupalCacheTest extends UnitTestCase
     public function testDoContains()
     {
         $drupalCache = $this->getDrupalCacheMock();
-        $drupalCache->shouldReceive('get')->once()->withArgs(['[foo][1]'])->andReturn('bar');
+        $drupalCache->shouldReceive('get')->once()->withArgs(['[foo][1]'])->andReturn($this->getCacheData('bar'));
         $drupalCache->shouldReceive('get')->once()->withArgs(['[bar][1]'])->andReturn(false);
 
         $cache = new DrupalCache($drupalCache);
@@ -83,5 +85,18 @@ class DrupalCacheTest extends UnitTestCase
         $drupalCache->shouldReceive('get')->withArgs(['DoctrineNamespaceCacheKey[]'])->andReturnNull();
 
         return $drupalCache;
+    }
+
+    /**
+     * @param $data
+     *
+     * @return StdClass
+     */
+    protected function getCacheData($data)
+    {
+      $cacheData = new StdClass();
+      $cacheData->data = $data;
+
+      return $cacheData;
     }
 }


### PR DESCRIPTION
I found a bug related to the Drupal cache implementation. This PR fix it.

"PHP message: TypeError: Argument 1 passed to Drupal\controller_annotations\EventSubscriber\ControllerEventSubscriber::getConfigurations() must be of the type array, object given"

Steps to reproduce:
1 - Enable Drupal Cache
2 - Load your route the first time, it should be fine
3 - Load you route the second time, you should have the error